### PR TITLE
Codecov Reports

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,6 +1,10 @@
 name: Tests
 
-on: pull_request
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   test:
@@ -15,6 +19,14 @@ jobs:
     - name: Check License Headers
       run: make license-header-check
     - name: Run Tests
-      run: make test
+      run: make test-ci
     - name: Check Licenses
       run: make license-check
+    # Upload coverage report if main is set
+    - name: Upload Coverage Report
+      uses: codecov/codecov-action@v2
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
+        files: all.coverprofile # optional
+        flags: unittests # optional
+        fail_ci_if_error: true # optional (default = false)

--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
   <img src="./docs/assets/dot_matrix_logo_go.png" alt="Nitric Logo"/>
 </p>
 
-# Nitric SDK for Go
-
+[![Go Report Card](https://goreportcard.com/badge/github.com/nitrictech/go-sdk)](https://goreportcard.com/report/github.com/nitrictech/go-sdk)
 ![test status](https://github.com/nitrictech/go-sdk/actions/workflows/test.yaml/badge.svg?branch=main)
+[![codecov](https://codecov.io/gh/nitrictech/go-sdk/branch/main/graph/badge.svg?token=TYH4QAZI07)](https://codecov.io/gh/nitrictech/go-sdk)
+
+# Nitric SDK for Go
 
 Client libarary for interfacing with the Nitric APIs as well as the creation of golang functions with Nitric.
 

--- a/makefile
+++ b/makefile
@@ -47,7 +47,11 @@ generate-mocks:
 	@echo Generating Mock RPC Clients
 	@go run github.com/golang/mock/mockgen github.com/nitrictech/go-sdk/interfaces/nitric/v1 DocumentServiceClient,EventServiceClient,TopicServiceClient,QueueServiceClient,StorageServiceClient,FaasServiceClient,FaasService_TriggerStreamClient,DocumentService_QueryStreamClient,SecretServiceClient > mocks/clients.go
 
+# Runs tests for coverage upload to codecov.io
+test-ci: generate-mocks
+	@echo Testing Nitric Go SDK
+	@go run github.com/onsi/ginkgo/ginkgo -cover -outputdir=./ -coverprofile=all.coverprofile ./...
+
 test: generate-mocks
 	@echo Testing Nitric Go SDK
-	@go run github.com/onsi/ginkgo/ginkgo -cover ./api/...
-	@go run github.com/onsi/ginkgo/ginkgo -cover ./faas/...
+	@go run github.com/onsi/ginkgo/ginkgo -cover ./...


### PR DESCRIPTION
Includes coverage and test status badges as well as go report card.

See: https://github.com/nitrictech/go-sdk/tree/feature/coverage-reports (note badge data will be populated once merged.)